### PR TITLE
Fix issue where rename followed by raise hand would corrupt name

### DIFF
--- a/joinmeeting.xaml.cs
+++ b/joinmeeting.xaml.cs
@@ -280,7 +280,17 @@ namespace RaiseHandApp
                     {
                         this.userName = userName;
                     }
+
                     this.textBox_DisplayName.Text = this.userName;
+
+                    if (settings.Participants.Count > 1)
+                    {
+                        this.userName = $"{this.userName} x {settings.Participants.Count}";
+                    }
+                    else
+                    {
+                        this.userName = $"{this.userName}";
+                    }
 
                     raisescreen.UpdateParticipants(this.userName, this.settings);
                 }


### PR DESCRIPTION
Fix issue where rename followed by raise hand would have the incorrect default name saved.